### PR TITLE
Remove duplicate declaration for liblight

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-display-hals := include libgralloc libgenlock libcopybit liblight
+display-hals := include libgralloc libgenlock libcopybit
 display-hals += libhwcomposer liboverlay libqdutils libhdmi libqservice
 display-hals += libmemtrack
 ifneq ($(TARGET_PROVIDES_LIBLIGHT),true)


### PR DESCRIPTION
it will get defined if TARGET_PROVIDES_LIBLIGHT is not defined